### PR TITLE
Fix AutoUlid Conflict With Auditable Trait

### DIFF
--- a/src/Triggers/AutoUlid.php
+++ b/src/Triggers/AutoUlid.php
@@ -7,7 +7,6 @@ trait AutoUlid
 	protected static function bootAutoUlid()
 	{
 		static::creating(function ($model) {
-			$model->incrementing = false;
 			$model->keyType = 'string';
 			$model->ulid = (string) \Str::orderedUuid();
 		});


### PR DESCRIPTION
The error you might encounter, Integrity constraint violation: 1048 Column 'subject_id' cannot be null, occurs because the 
Auditable trait is attempting to create an audit log record for your new Model before it has an ID assigned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-increment behavior in ULID generation to respect default model configuration settings instead of forcing disabled state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->